### PR TITLE
Исправлен поиск tsconfig.json в проекте

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 Инструменты полезны для разработчиков, которые работают с WebSoftHCM и хотят упростить процесс разработки, обеспечивая быструю и корректную работу с исходным кодом.
 
 ## Основные возможности
+
 - Сборка проекта: Выполняет полную сборку, преобразуя исходный код в совместимый с WebSoftHCM формат.
 - Отслеживание изменений: Запускает процесс транспиляции автоматически при изменении исходных файлов, что помогает мгновенно видеть результаты в реальном времени.
 - Транспиляция в WebSoftHCM синтаксис: Преобразует современный JavaScript или TypeScript в код, поддерживаемый WebSoftHCM, с учетом всех его особенностей.
 
 ## Как использовать
+
 1. Установите CLI-инструмент локально в проект при необходимости:
 
 ```bash
@@ -34,14 +36,16 @@ npx wshcmx build
 npx wshcmx watch
 ```
 
-## Флаги
-CLI поддерживает флаги:
+## Параметры
 
-| Флаг | Описание |
-| - | - |
-| **--include-non-ts-files** | Добавляет копирование файлов с любым расширением **не _js_/_ts_**.\ Файлы обрабатываются по логике **include**, **files** и **exclude** в **tsconfig.json** |
-| **--retain-non-ascii-characters** | Декодирует не ASCII символы после транспиляции |
-| **--retain-imports-as-comments** | Оставляет импорты в комментариях |
+CLI поддерживает параметры:
+
+| Флаг                              | Описание                                                                                                                                                    |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **--project**| Директория, в которой хранится tsconfig.json или путь до самого файла конфигурации |
+| **--include-non-ts-files**        | Добавляет копирование файлов с любым расширением **не _js_/_ts_**.\ Файлы обрабатываются по логике **include**, **files** и **exclude** в **tsconfig.json** |
+| **--retain-non-ascii-characters** | Декодирует не ASCII символы после транспиляции                                                                                                              |
+| **--retain-imports-as-comments**  | Оставляет импорты в комментариях                                                                                                                            |
 
 ## Основные особенности
 
@@ -53,7 +57,7 @@ TypeScript позволяет из коробки пользоваться не�
 
 ```ts
 function method(argument: string = "default string") {
-    // ...
+  // ...
 }
 ```
 
@@ -93,7 +97,7 @@ var Locales = {
 import { wshcmx } from "@wshcmx/lib";
 
 export function method() {
-    // ...
+  // ...
 }
 
 // -->
@@ -120,7 +124,6 @@ alert("I insisted that substring be ".concat(stringState));
 
 CLI конвертирует это в формат, похожий на TypeScript до 4.4.4.
 
-
 ```ts
 var stringState = "interpolated";
 alert(`I insisted that substring be ${stringState}`);
@@ -134,22 +137,23 @@ alert("I insisted that substring be " + stringState + "");
 
 ```ts
 export namespace Module {
-    export const VARIABLE = "VARIABLE_VALUES";
-    export function method() {
-        // ...
-    }
+  export const VARIABLE = "VARIABLE_VALUES";
+  export function method() {
+    // ...
+  }
 }
 
 // -->
 
-"META:NAMESPACE:Module";
+("META:NAMESPACE:Module");
 var VARIABLE = "VARIABLE_VALUES";
 function method() {
-    // ...
+  // ...
 }
 ```
 
 ## Контрибуция
+
 Контрибуции приветствуются! Пожалуйста, создайте Pull Request или свяжитесь с нами через Issues, если у вас есть предложения или обнаружены ошибки.
 
 ## Лицензия: MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wshcmx/cli",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wshcmx/cli",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "MIT",
       "workspaces": [
         "./test/project"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wshcmx/cli",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "type": "module",
   "repository": "github:wshcmx/cli",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,11 +1,11 @@
-import { args } from '../core/args.js';
+import { args, ArgsFlags } from '../core/args.js';
 import { buildNonTypescriptFiles, buildTypescriptFiles } from '../core/build.js';
 import { getTSConfig } from '../core/config.js';
 import { logger } from '../core/logger.js';
 
 export function build(cwd: string) {
   logger.success(`🔨 ${new Date().toLocaleTimeString()} Project building started`);
-  const configuration = getTSConfig(cwd, args.getArg('project'));
+  const configuration = getTSConfig(args.get(ArgsFlags.PROJECT) ?? cwd);
 
   const result = buildTypescriptFiles(configuration);
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,9 +1,9 @@
-import { args } from '../core/args.js';
+import { args, ArgsFlags } from '../core/args.js';
 import { watchNonTypescriptFiles, watchTypescriptFiles } from '../core/build.js';
 import { getTSConfig } from '../core/config.js';
 
 export function watch(cwd: string) {
-  const configuration = getTSConfig(cwd, args.getArg('project'));
+  const configuration = getTSConfig(args.get(ArgsFlags.PROJECT) ?? cwd);
   watchTypescriptFiles(configuration);
   watchNonTypescriptFiles(configuration);
 }

--- a/src/core/args.ts
+++ b/src/core/args.ts
@@ -1,32 +1,41 @@
 export enum ArgsFlags {
   INCLUDE_NON_TS_FILES = 'include-non-ts-files',
+  PROJECT = 'project',
   RETAIN_IMPORTS_AS_COMMENTS = 'retain-imports-as-comments',
   RETAIN_NON_ASCII_CHARACTERS = 'retain-non-ascii-characters',
 }
 
 class ArgsParser {
-  #command: string = '';
-  #argv: string[] = [];
+  command: string = '';
+  private args: Map<string, string> = new Map();
 
   constructor() {
-    this.#parse();
+    this.parse();
   }
 
-  getArg(argName: string) {
-    return process.argv.slice(2).find(x => x.startsWith('--') && x.slice(2) === argName);
+  get(name: ArgsFlags) {
+    return this.args.get(name);
   }
 
-  getCommand() {
-    return this.#command;
+  has(name: ArgsFlags) {
+    return this.args.get(name) !== undefined;
   }
 
-  has(argumentName: ArgsFlags) {
-    return this.#argv.includes(argumentName);
-  }
+  private parse() {
+    this.command = process.argv.slice(2)[0];
+    const args = process.argv.slice(3);
 
-  #parse() {
-    this.#command = process.argv.slice(2)[0];
-    this.#argv = process.argv.slice(3).filter(x => x.startsWith('--')).map(x => x.slice(2));
+    for (let i = 0; i < args.length; i++) {
+      if (!args[i].startsWith('--')) {
+        continue;
+      }
+
+      if (!args[i + 1]?.startsWith('--')) {
+        this.args.set(args[i].slice(2), args[i + 1]);
+      } else {
+        this.args.set(args[i].slice(2), '');
+      }
+    }
   }
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,26 @@
+import { existsSync, lstatSync } from 'node:fs';
+import { parse } from 'node:path';
+
 import ts from 'typescript';
 
 import { logger } from './logger.js';
 
-export function getTSConfig(cwd: string, project: string = 'tsconfig.json'): ts.ParsedCommandLine {
-  const tsconfigPath = ts.findConfigFile(cwd, ts.sys.fileExists, project);
+export function getTSConfig(cwd: string): ts.ParsedCommandLine {
+  if (!existsSync(cwd)) {
+    logger.error(`The project path "${cwd}" does not exist.`);
+    process.exit(1);
+  }
+
+  let configName = 'tsconfig.json';
+  let path = cwd;
+
+  if (!lstatSync(cwd).isDirectory()) {
+    const { base, dir } = parse(cwd);
+    configName = base;
+    path = dir;
+  }
+
+  const tsconfigPath = ts.findConfigFile(path, ts.sys.fileExists, configName);
 
   if (!tsconfigPath) {
     logger.error(`There is no any configuration files at "${cwd}". Execute npx tsc -init to create a new one.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { help } from './commands/help.js';
 
 const cwd = process.cwd();
 
-const command = commands.get(args.getCommand());
+const command = commands.get(args.command);
 
 if (command) {
   command.callback(cwd);

--- a/test/transformers/case_1/case.test.js
+++ b/test/transformers/case_1/case.test.js
@@ -14,7 +14,7 @@ suite('Suite', () => {
   const code = readFileSync(join(import.meta.dirname, 'case.ts'), 'utf-8');
 
   test('Test', (t) => {
-    const configuration = getTSConfig(join(import.meta.dirname, '..', 'project'));
+    const configuration = getTSConfig(join(import.meta.dirname, '..', '..', 'project'));
     const sourceFile = ts.createSourceFile('', code, ts.ScriptTarget.ES2015, true, ts.ScriptKind.TS);
     const result = ts.transform(sourceFile, [removeExports(), enumsToObjects(), convertTemplateStrings(), transformNamespaces(),], configuration.options);
     const transformedSourceFile = result.transformed[0];


### PR DESCRIPTION
Теперь для команд build и watch используется tsconfig.json, который указывается из параметра --project, иначе мы получаем файл конфигурации из корня проекта.

Обновлена работа парсера параметров командной строки.

Обновлен README.md.